### PR TITLE
Make plotting in tests optional.

### DIFF
--- a/tests/test_gpmcc_simple_composite.py
+++ b/tests/test_gpmcc_simple_composite.py
@@ -19,10 +19,7 @@ features of State."""
 
 import pytest
 
-import matplotlib.pyplot as plt
 import numpy as np
-
-from matplotlib import cm
 
 from cgpm.cgpm import CGpm
 from cgpm.crosscat.state import State
@@ -32,15 +29,21 @@ from cgpm.utils import general as gu
 from cgpm.utils import test as tu
 
 
+PLOT = False
+
+
 def generate_quadrants(rows, rng):
     Q0 = rng.multivariate_normal([2,2], cov=[[.5,0],[0,.5]], size=rows/4)
     Q1 = rng.multivariate_normal([-2,2], cov=[[.5,0],[0,.5]], size=rows/4)
     Q2 = rng.multivariate_normal([-2,-2], cov=[[.5,0],[0,.5]], size=rows/4)
     Q3 = rng.multivariate_normal([2,-2], cov=[[.5,0],[0,.5]], size=rows/4)
-    colors = iter(cm.gist_rainbow(np.linspace(0, 1, 4)))
-    for q in [Q0, Q1, Q2, Q3]:
-        plt.scatter(q[:,0], q[:,1], color=next(colors))
-    plt.close('all')
+    if PLOT:
+        import matplotlib.pyplot as plt
+        from matplotlib import cm
+        colors = iter(cm.gist_rainbow(np.linspace(0, 1, 4)))
+        for q in [Q0, Q1, Q2, Q3]:
+            plt.scatter(q[:,0], q[:,1], color=next(colors))
+        plt.close('all')
     return np.row_stack((Q0, Q1, Q2, Q3))
 
 
@@ -152,13 +155,16 @@ def test_inference_quality__ci_(state):
         simulate_fourway_constrain = np.transpose(
             np.asarray([[s[0] for s in samples], [s[2] for s in samples]]))
 
-        fig, ax = plt.subplots()
-        ax.scatter(
-            simulate_fourway_constrain[:,0],
-            simulate_fourway_constrain[:,1])
-        ax.hlines(0, *ax.get_xlim(),color='red', linewidth=2)
-        ax.vlines(0, *ax.get_ylim(),color='red', linewidth=2)
-        ax.grid()
+        if PLOT:
+            import matplotlib.pyplot as plt
+            from matplotlib import cm
+            fig, ax = plt.subplots()
+            ax.scatter(
+                simulate_fourway_constrain[:,0],
+                simulate_fourway_constrain[:,1])
+            ax.hlines(0, *ax.get_xlim(),color='red', linewidth=2)
+            ax.vlines(0, *ax.get_ylim(),color='red', linewidth=2)
+            ax.grid()
 
         x0, x1 = FourWay.retrieve_y_for_x(v)
         simulate_ideal = np.asarray([[x0, x1]])

--- a/tests/test_linreg.py
+++ b/tests/test_linreg.py
@@ -17,13 +17,15 @@
 import importlib
 import pytest
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 from cgpm.regressions.linreg import LinearRegression
 from cgpm.utils import config as cu
 from cgpm.utils import general as gu
 from cgpm.utils import test as tu
+
+
+PLOT = False
 
 
 CCTYPES, DISTARGS = cu.parse_distargs([
@@ -145,7 +147,9 @@ def test_simulate():
         metadata['factory'][1])
     linreg = builder.from_metadata(metadata, rng=gu.gen_rng(1))
 
-    _, ax = plt.subplots()
+    if PLOT:
+        import matplotlib.pyplot as plt
+        _, ax = plt.subplots()
     xpred, xtrue = [], []
     for row in D[25:]:
         xtrue.append(row[0])
@@ -156,10 +160,11 @@ def test_simulate():
     xmeans = np.mean(xpred, axis=1)
     xlow = np.percentile(xpred, 25, axis=1)
     xhigh = np.percentile(xpred, 75, axis=1)
-    ax.plot(range(len(xtrue)), xmeans, color='g')
-    ax.fill_between(range(len(xtrue)), xlow, xhigh, color='g', alpha='.3')
-    ax.scatter(range(len(xtrue)), xtrue, color='r')
-    # plt.close('all')
+    if PLOT:
+        ax.plot(range(len(xtrue)), xmeans, color='g')
+        ax.fill_between(range(len(xtrue)), xlow, xhigh, color='g', alpha='.3')
+        ax.scatter(range(len(xtrue)), xtrue, color='r')
+        # plt.close('all')
 
 
 def test_missing_inputs():

--- a/tests/test_linreg_mixture.py
+++ b/tests/test_linreg_mixture.py
@@ -17,10 +17,12 @@
 
 import numpy as np
 import matplotlib.cm as cm
-import matplotlib.pyplot as plt
 
 from cgpm.crosscat.state import State
 from cgpm.utils import general as gu
+
+
+PLOT = False
 
 
 def _compute_y(x):
@@ -61,6 +63,7 @@ def generate_regression_samples():
     return [replace_key(s, view.outputs[0], -1) for s in samples]
 
 def plot_samples(samples, title):
+    import matplotlib.pyplot as plt
     fig, ax = plt.subplots()
     clusters = set(s[-1] for s in samples)
     colors = iter(cm.gist_rainbow(np.linspace(0, 1, len(clusters)+2)))
@@ -79,6 +82,7 @@ def plot_samples(samples, title):
 def test_regression_plot_crash__ci_():
     samples_a = generate_gaussian_samples()
     samples_b = generate_regression_samples()
-    plot_samples(samples_a, 'Model: Mixture of 2D Gaussians')
-    plot_samples(samples_b, 'Model: Mixture of Linear Regression')
-    # plt.close('all')
+    if PLOT:
+        plot_samples(samples_a, 'Model: Mixture of 2D Gaussians')
+        plot_samples(samples_b, 'Model: Mixture of Linear Regression')
+        # plt.close('all')

--- a/tests/test_normal_categorical.py
+++ b/tests/test_normal_categorical.py
@@ -29,7 +29,6 @@ Simulations are compared to synthetic data at indicator subpopulations.
 
 import pytest
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 from scipy.stats import ks_2samp
@@ -37,6 +36,9 @@ from scipy.stats import ks_2samp
 from cgpm.crosscat.engine import Engine
 from cgpm.utils import general as gu
 from cgpm.utils import test as tu
+
+
+PLOT = False
 
 
 N_SAMPLES = 250
@@ -72,60 +74,77 @@ def state():
 def test_joint(state):
     # Simulate from the joint distribution of (x,z).
     joint_samples = state.simulate(-1, [0,1], N=N_SAMPLES)
-    _, ax = plt.subplots()
-    ax.set_title('Joint Simulation')
+    if PLOT:
+        import matplotlib.pyplot as plt
+        _, ax = plt.subplots()
+        ax.set_title('Joint Simulation')
     for t in INDICATORS:
         # Plot original data.
         data_subpop = DATA[DATA[:,1] == t]
-        ax.scatter(data_subpop[:,1], data_subpop[:,0], color=gu.colors[t])
+        if PLOT:
+            ax.scatter(data_subpop[:,1], data_subpop[:,0], color=gu.colors[t])
         # Plot simulated data for indicator t.
         samples_subpop = [j[0] for j in joint_samples if j[1] == t]
-        ax.scatter(
-            np.add([t]*len(samples_subpop), .25), samples_subpop,
-            color=gu.colors[t])
+        if PLOT:
+            ax.scatter(
+                np.add([t]*len(samples_subpop), .25), samples_subpop,
+                color=gu.colors[t])
         # KS test.
         pvalue = ks_2samp(data_subpop[:,0], samples_subpop)[1]
         assert .05 < pvalue
-    ax.set_xlabel('Indicator')
-    ax.set_ylabel('x')
-    ax.grid()
+    if PLOT:
+        ax.set_xlabel('Indicator')
+        ax.set_ylabel('x')
+        ax.grid()
 
 
 def test_conditional_indicator(state):
     # Simulate from the conditional X|Z
-    _, ax = plt.subplots()
-    ax.set_title('Conditional Simulation Of Data X Given Indicator Z')
+    if PLOT:
+        import matplotlib.pyplot as plt
+        _, ax = plt.subplots()
+        ax.set_title('Conditional Simulation Of Data X Given Indicator Z')
     for t in INDICATORS:
         # Plot original data.
         data_subpop = DATA[DATA[:,1] == t]
-        ax.scatter(data_subpop[:,1], data_subpop[:,0], color=gu.colors[t])
+        if PLOT:
+            ax.scatter(data_subpop[:,1], data_subpop[:,0], color=gu.colors[t])
         # Plot simulated data.
         samples_subpop = [s[0] for s in
             state.simulate(-1, [0], evidence={1:t}, N=len(data_subpop))]
-        ax.scatter(
-            np.repeat(t, len(data_subpop)) + .25,
-            samples_subpop, color=gu.colors[t])
+        if PLOT:
+            ax.scatter(
+                np.repeat(t, len(data_subpop)) + .25,
+                samples_subpop, color=gu.colors[t])
         # KS test.
         pvalue = ks_2samp(data_subpop[:,0], samples_subpop)[1]
         assert .1 < pvalue
-    ax.set_xlabel('Indicator')
-    ax.set_ylabel('x')
-    ax.grid()
+    if PLOT:
+        ax.set_xlabel('Indicator')
+        ax.set_ylabel('x')
+        ax.grid()
 
 
 def test_conditional_real(state):
     # Simulate from the conditional Z|X
-    fig, axes = plt.subplots(2,3)
-    fig.suptitle('Conditional Simulation Of Indicator Z Given Data X')
+    if PLOT:
+        import matplotlib.pyplot as plt
+        fig, axes = plt.subplots(2,3)
+        fig.suptitle('Conditional Simulation Of Indicator Z Given Data X')
     # Compute representative data sample for each dindicator.
     means = [np.mean(DATA[DATA[:,1]==t], axis=0)[0] for t in INDICATORS]
-    for mean, indicator, ax in zip(means, INDICATORS, axes.ravel('F')):
-        samples_subpop = [s[1] for s in
-            state.simulate(-1, [1], evidence={0:mean}, N=N_SAMPLES)]
-        ax.hist(samples_subpop, color='g', alpha=.4)
-        ax.set_title('True Indicator %d' % indicator)
-        ax.set_xlabel('Simulated Indicator')
-        ax.set_xticks(INDICATORS)
-        ax.set_ylabel('Frequency')
-        ax.set_ylim([0, ax.get_ylim()[1]+10])
-        ax.grid()
+    if PLOT:
+        for mean, indicator, ax in zip(means, INDICATORS, axes.ravel('F')):
+            samples_subpop = [s[1] for s in
+                state.simulate(-1, [1], evidence={0:mean}, N=N_SAMPLES)]
+            ax.hist(samples_subpop, color='g', alpha=.4)
+            ax.set_title('True Indicator %d' % indicator)
+            ax.set_xlabel('Simulated Indicator')
+            ax.set_xticks(INDICATORS)
+            ax.set_ylabel('Frequency')
+            ax.set_ylim([0, ax.get_ylim()[1]+10])
+            ax.grid()
+    else:
+        for mean, indicator in zip(means, INDICATORS):
+            samples_subpop = [s[1] for s in
+                state.simulate(-1, [1], evidence={0:mean}, N=N_SAMPLES)]

--- a/tests/test_uncorrelated_simulate.py
+++ b/tests/test_uncorrelated_simulate.py
@@ -26,7 +26,6 @@ Moreover a wider set of test cases for _conditional_ simulate are required.
 import itertools
 import pytest
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 from cgpm.uncorrelated.diamond import Diamond
@@ -38,6 +37,9 @@ from cgpm.uncorrelated.sin import Sin
 from cgpm.uncorrelated.xcross import XCross
 
 from cgpm.utils.general import gen_rng
+
+
+PLOT = False
 
 
 NUM_SAMPLES = 200
@@ -80,17 +82,21 @@ def simulate_dataset(dist, noise, size=200):
     return np.asarray(D)
 
 def plot_synthetic(dist, noise, size=1000):
-    fig, ax = plt.subplots()
+    if PLOT:
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots()
     T = simulate_dataset(dist, noise, size=size)
-    ax.set_title('%s Distribution (Noise %1.2f)' % (dist, noise))
-    ax.scatter(T[:,0], T[:,1], color='k', alpha=.5, label='True Distribution')
-    ax.set_xlabel('x1')
-    ax.set_ylabel('x2')
-    ax.grid()
-    ax.set_xlim(simulator_limits[dist][0])
-    ax.set_ylim(simulator_limits[dist][1])
-    fig.savefig('/tmp/synth_%s_%1.2f.png' % (dist, noise))
-    plt.close('all')
+    if PLOT:
+        ax.set_title('%s Distribution (Noise %1.2f)' % (dist, noise))
+        ax.scatter(T[:,0], T[:,1], color='k', alpha=.5,
+            label='True Distribution')
+        ax.set_xlabel('x1')
+        ax.set_ylabel('x2')
+        ax.grid()
+        ax.set_xlim(simulator_limits[dist][0])
+        ax.set_ylim(simulator_limits[dist][1])
+        fig.savefig('/tmp/synth_%s_%1.2f.png' % (dist, noise))
+        plt.close('all')
 
 @pytest.mark.parametrize('dist, noise', itertools.product(simulators, NOISES))
 def test_dist_noise__ci_(dist, noise):


### PR DESCRIPTION
The plotting was, as I understand it, already intended to be used only interactively anyway.  If you want to run a test interactively *and* get plots now, instead of just doing

    import test_whatever
    test_whatever.test_case()

you'll have to do

    import test_whatever
    test_whatever.PLOT = True
    test_whatever.test_case()

This way the automatic tests are unaffected by vagaries of the matplotlib backends, e.g. requiring $DISPLAY to be set in some cases in order to function at all.