### PR TITLE
Create Ubuntu 14.04 apt-only dockerfile for use with jenkins build.

### DIFF
--- a/docker/ubuntu1404
+++ b/docker/ubuntu1404
@@ -2,6 +2,7 @@ FROM            ubuntu:14.04
 MAINTAINER      MIT Probabilistic Computing Project
 
 RUN             apt-get update -qq
+RUN             apt-get upgrade -qq
 RUN             apt-get install -qq git
 RUN             apt-get install -qq python-matplotlib
 RUN             apt-get install -qq python-numpy

--- a/docker/ubuntu1404
+++ b/docker/ubuntu1404
@@ -15,3 +15,5 @@ RUN             apt-get install -qq python-statsmodels
 ADD             . /cgpm
 WORKDIR         /cgpm
 RUN             ./check.sh
+RUN             python setup.py sdist
+RUN             python setup.py bdist

--- a/docker/ubuntu1404
+++ b/docker/ubuntu1404
@@ -1,0 +1,16 @@
+FROM            ubuntu:14.04
+MAINTAINER      MIT Probabilistic Computing Project
+
+RUN             apt-get update -qq
+RUN             apt-get install -qq git
+RUN             apt-get install -qq python-matplotlib
+RUN             apt-get install -qq python-numpy
+RUN             apt-get install -qq python-pandas
+RUN             apt-get install -qq python-pytest
+RUN             apt-get install -qq python-scipy
+RUN             apt-get install -qq python-sklearn
+RUN             apt-get install -qq python-statsmodels
+
+ADD             . /cgpm
+WORKDIR         /cgpm
+RUN             ./check.sh

--- a/src/crosscat/state.py
+++ b/src/crosscat/state.py
@@ -33,7 +33,6 @@ from cgpm.network.helpers import retrieve_ancestors
 from cgpm.network.importance import ImportanceNetwork
 from cgpm.utils import config as cu
 from cgpm.utils import general as gu
-from cgpm.utils import plots as pu
 from cgpm.utils import validation as vu
 
 
@@ -629,6 +628,7 @@ class State(CGpm):
     def plot(self):
         """Plots observation histogram and posterior distirbution of Dims."""
         import matplotlib.pyplot as plt
+        from cgpm.utils import plots as pu
         layout = pu.get_state_plot_layout(self.n_cols())
         fig = plt.figure(
             num=None,

--- a/src/mixtures/dim.py
+++ b/src/mixtures/dim.py
@@ -21,7 +21,6 @@ import numpy as np
 from cgpm.cgpm import CGpm
 from cgpm.utils import config as cu
 from cgpm.utils import general as gu
-from cgpm.utils import plots as pu
 
 
 class Dim(CGpm):
@@ -211,6 +210,7 @@ class Dim(CGpm):
 
     def plot_dist(self, X, Y=None, ax=None):
         """Plots predictive distribution and a histogram of data X."""
+        from cgpm.utils import plots as pu
         plotter = pu.plot_dist_continuous if self.model.is_continuous() else \
             pu.plot_dist_discrete
         return plotter(


### PR DESCRIPTION
Also tweak import of plotting stuff so that matplotlib is not needed for clients that don't try to do plotting, e.g. the bayeslite tests.