### PR TITLE
Categorical primitive: changed Dirichlet alpha parameter in predictive logpdf to be divided …

### DIFF
--- a/src/primitives/categorical.py
+++ b/src/primitives/categorical.py
@@ -141,7 +141,7 @@ class Categorical(DistributionGpm):
     @staticmethod
     def calc_predictive_logp(x, N, counts, alpha):
         numer = log(alpha + counts[x])
-        denom = log(np.sum(counts) + alpha * len(counts))
+        denom = log(np.sum(counts) + alpha * (len(counts) / self.k))
         return numer - denom
 
     @staticmethod


### PR DESCRIPTION
…by number of categories.

In the documentation for the Categorical primitive cgpm, 

    """Categorical distribution with symmetric dirichlet prior on
    category weight vector v.
    k := distarg
    v ~ Symmetric-Dirichlet(alpha/k)
    x ~ Categorical(v)
    http://www.cs.berkeley.edu/~stephentu/writeups/dirichlet-conjugate-prior.pdf
    """

However, when computing the predictive logpdf, the Dirichlet parameter that was used was only `alpha`. I changed it to `alpha/k`

I did not create any new test for this functionality.

I did run `check.sh` and the only tests failing were `test_incorporate_row.py` and `test_normal_categorical.py`. However, these tests also failed when run in the master branch. 