### PR TITLE
20180212 schaechtle test coverage

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -31,8 +31,7 @@ test:
   imports:
     - cgpm
   commands:
-    - python -m pytest --pyargs cgpm -k "not __ci_"
-    - python -m pytest --pyargs cgpm -k __ci_
+    - python -m pytest --pyargs cgpm
 
 about:
   home: https://github.com/probcomp/cgpm

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -32,6 +32,7 @@ test:
     - cgpm
   commands:
     - python -m pytest --pyargs cgpm -k "not __ci_"
+    - python -m pytest --pyargs cgpm -k __ci_
 
 about:
   home: https://github.com/probcomp/cgpm


### PR DESCRIPTION
ci tests seem to run in 110 seconds on Travis. I thus vote we just include them here.