### PR TITLE
patch to loomcat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ docs/_build/
 *_minted-*
 *.pdf
 
+# vim artifacts
+*.swp
+
 # specific directories
 examples/malawi/resources/
 examples/satellites/splits/


### PR DESCRIPTION
This patch is needed since the column names I am getting from loom while calling `_update_state`
(and `_retrieve_featureid_to_cgpm`, specifically) don't follow the assumptions made in the code. In fact, the column names I am getting from loom are the actual natural language column names which seems correct (thus patching cgpm).

I have a test case for this patch which depends on loom and bql -- I initially planned to include the
test case here (i.e the cgpm repo). Looking at the test suite however, I am not sure anymore if this makes sense (not much loom and BQL around in `cgpm/test`); I am now planning to include this test in another repo focussed only on exporting models from loom. Open for suggestions here.

Tested using the probcomp dev image as folllows:
```
 2018-08-13 14:47:24 ⌚  ulli-notebook in ~/cgpm
○ → pytest tests/
```
Result:
```
454 passed, 8 skipped, 2 xfailed in 363.28 seconds
```
