### PR TITLE
Fix build by adding a dependency on nomkl

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,6 +15,7 @@ requirements:
     - numpy 1.11.*
     - python 2.7.*
   run:
+    - nomkl
     - matplotlib 1.5.*
     - numpy 1.11.*
     - pandas 0.18.*
@@ -25,7 +26,6 @@ requirements:
 
 test:
   requires:
-    - nomkl
     - matplotlib 1.5.*
     - pytest 2.8.*
     - python 2.7.*

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,6 +25,7 @@ requirements:
 
 test:
   requires:
+    - nomkl
     - matplotlib 1.5.*
     - pytest 2.8.*
     - python 2.7.*


### PR DESCRIPTION
For some time now the Travis CI builds for `probcomp/bayeslite` `probcomp/cgpm`, and `probcomp/Venturecxx` have all been failing with the following error. 

```
Intel MKL FATAL ERROR: Cannot load libmkl_avx2.so or libmkl_def.so.
```

Some even started failing without any commits having been pushed up to `master` which would suggest that the failures are due to a shift in the dependencies being pushed by `conda`. 

MKL, also known as the [Intel® Math Kernel Library](https://software.intel.com/en-us/mkl), is a proprietary math library for us on Intel hardware. Conda, our build tool, provides versions of our dependencies that include MKL and others that do not. Our (my and @fsaad's) hypothesis here is that some shift in the underlying build environment caused our packages to start being build with MKL whereas the test environment does not have MKL available.

This pull request adds a dependency on the `nomkl` package, which appears to be the recommended way of opting out of MKL support for `numpy` and other dependencies of ours.

