### PR TITLE
Fix sqlalchemy dependency

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - matplotlib 1.5.*
     - numpy 1.11.*
     - python 2.7.*
+    - sqlalchemy 1.3.18
   run:
     - nomkl
     - matplotlib 1.5.*
@@ -23,6 +24,7 @@ requirements:
     - scikit-learn 0.17.*
     - scipy 0.17.*
     - statsmodels 0.6.*
+    - sqlalchemy 1.3.18
 
 test:
   requires:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,7 +14,6 @@ requirements:
     - matplotlib 1.5.*
     - numpy 1.11.*
     - python 2.7.*
-    - sqlalchemy 1.3.18
   run:
     - nomkl
     - matplotlib 1.5.*
@@ -24,7 +23,6 @@ requirements:
     - scikit-learn 0.17.*
     - scipy 0.17.*
     - statsmodels 0.6.*
-    - sqlalchemy 1.3.18
 
 test:
   requires:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - matplotlib 1.5.*
     - numpy 1.11.*
     - python 2.7.*
+    - sqlalchemy 1.3.1
   run:
     - nomkl
     - matplotlib 1.5.*
@@ -23,6 +24,7 @@ requirements:
     - scikit-learn 0.17.*
     - scipy 0.17.*
     - statsmodels 0.6.*
+    - sqlalchemy 1.3.1
 
 test:
   requires:


### PR DESCRIPTION
We got a requirement by our industrial collaborator to bump the version of sqlalchemy.
 sqlalchemy is a dependency of CGPM. I tracked this down to CGPM through our build system (when I set the sqlalchemy version in our image itself -- Conda's sat solver found incompatibility with Bayeslite. When I set  the version in Bayeslite Conda's sat solver found incompatibility CGPM. CGPM seems to be happy with an upgraded version.